### PR TITLE
fix: getImage 필터에 걸리는 문제  해결

### DIFF
--- a/src/main/java/study/gongsa/service/ImageService.java
+++ b/src/main/java/study/gongsa/service/ImageService.java
@@ -1,5 +1,6 @@
 package study.gongsa.service;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.UrlResource;
 import org.springframework.http.HttpStatus;
@@ -17,6 +18,7 @@ import java.nio.file.Paths;
 import java.util.stream.Stream;
 
 @Service
+@Slf4j
 public class ImageService {
     private final Path root = Paths.get("image"); // controller, service 폴더 있는 곳
 
@@ -49,6 +51,7 @@ public class ImageService {
                 throw new IllegalStateExceptionWithLocation(HttpStatus.BAD_REQUEST, "image", "이미지를 불러올 수 없습니다.");
             }
         } catch (MalformedURLException e) {
+            log.error("이미지 로드 실패 {} {}", e.getClass(), e.getMessage());
             throw new IllegalStateExceptionWithLocation(HttpStatus.BAD_REQUEST, "image", "이미지를 불러올 수 없습니다.");
         }
     }

--- a/src/main/java/study/gongsa/support/filter/LogFilter.java
+++ b/src/main/java/study/gongsa/support/filter/LogFilter.java
@@ -34,6 +34,11 @@ public class LogFilter implements Filter {
         ContentCachingResponseWrapper httpServletResponse = new ContentCachingResponseWrapper((HttpServletResponse) response);
         chain.doFilter(httpServletRequest, httpServletResponse);
 
+        if(httpServletRequest.getRequestURI().contains("/api/image/")){
+            log.info("[REQUEST] {}\n[RESPONSE] {}:{}", httpServletRequest.getRequestURI(), httpServletResponse.getStatus(), httpServletResponse.getContentSize());
+            return;
+        }
+
         RequestLog requestLog = RequestLog.builder()
                 .method(httpServletRequest.getMethod())
                 .URI(httpServletRequest.getRequestURI())

--- a/src/test/java/study/gongsa/controller/ImageControllerTest.java
+++ b/src/test/java/study/gongsa/controller/ImageControllerTest.java
@@ -1,0 +1,117 @@
+package study.gongsa.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+import study.gongsa.domain.User;
+import study.gongsa.domain.UserAuth;
+import study.gongsa.dto.JoinRequest;
+import study.gongsa.repository.UserAuthRepository;
+import study.gongsa.repository.UserRepository;
+import study.gongsa.support.jwt.JwtTokenProvider;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+@Slf4j
+class ImageControllerTest {
+    private static String baseURL = "/api/image";
+    private Integer userUID;
+    private String accessToken;
+    private String refreshToken;
+
+    @Autowired
+    private WebApplicationContext context;
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private UserAuthRepository userAuthRepository;
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .addFilter(new CharacterEncodingFilter("UTF-8", true)) //한글 설정
+                .build();
+
+        // 테스트 위한 데이터
+        User user = User.builder()
+                .email("gong40sa04@gmail.com")
+                .passwd(passwordEncoder.encode("12345678"))
+                .nickname("통합테스트")
+                .authCode("00000a")
+                .isAuth(true)
+                .build();
+        userUID = userRepository.save(user).intValue();
+
+        refreshToken = jwtTokenProvider.makeRefreshToken(userUID);
+        Integer userAuthUID = userAuthRepository.save(UserAuth.builder()
+                .userUID(userUID)
+                .refreshToken(refreshToken)
+                .build()).intValue();
+        accessToken = jwtTokenProvider.makeAccessToken(userUID, userAuthUID);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+    }
+
+    @Test
+    void 이미지조회_성공() throws Exception {
+        // when
+        ResultActions resultActions = mockMvc.perform(get(baseURL+"/r0.jpg")
+                        .header("Authorization", "Bearer "+accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void 이미지조회_실패() throws Exception {
+        // when
+        ResultActions resultActions = mockMvc.perform(get(baseURL+"/r-1.jpg")
+                        .header("Authorization", "Bearer "+accessToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
- 상황 : com.fasterxml.jackson.core.JsonParseException: Invalid UTF-8 middle byte 0xff 발생
- 원인 : getImage의 response값은 이미지 파일이라 doFilter에서 response json화 과정에서 에러 발생
- 해결 방안 : 특정 url 경로에만 filter를 적용할 순 있어도, 특정 url 경로를 제외할 순 없다고 한다. 직접 getRequestURI해서 제외해주었다.